### PR TITLE
[ED] "Unsubscribe" in heading for Discussion List

### DIFF
--- a/_about/groups/ig.md
+++ b/_about/groups/ig.md
@@ -81,7 +81,7 @@ searching for past messages and getting a feel for the list.
 -   **Send any questions about the WAI IG mailing list to
     <shawn@w3.org>**, not to the whole list.
 
-### Subscribing to the Discussion List
+### Discussion List - Subscribing and Unsubscribing
 
 -   **To subscribe** to the list, send e-mail to <a href="mailto:w3c-wai-ig-request@w3.org?subject=subscribe">w3c-wai-ig-request@w3.org with subject: &ldquo;subscribe&rdquo;</a>.
 -   **To unsubscribe** from the list, send e-mail to <a href="mailto:w3c-wai-ig-request@w3.org?subject=unsubscribe">w3c-wai-ig-request@w3.org with subject: &ldquo;unsubscribe&rdquo;</a>.


### PR DESCRIPTION
There is "Subscribe and Unsubscribe" in the heading for the Announcements List, but not for the Discussion List. This makes it harder to scan for "Unscubscribe" in the headings.