### PR TITLE
Update pages in Translating section

### DIFF
--- a/_about/translating.md
+++ b/_about/translating.md
@@ -7,16 +7,16 @@ github:
   
 permalink: /about/translating/
 ref: /about/translating/
-last_updated: 2023-11-06
+last_updated: 2023-11-09
 lang: en
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 6 November 2023.</p>
-  <p><strong>Editor:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
-  <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Developed with support from the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a>, funded by the Ford Foundation.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>). Developed with support from the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a>, funded by the Ford Foundation. Updated as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::nomarkdown}
@@ -61,12 +61,12 @@ Thank you for your interest in translating resources from the World Wide Web Con
 
 To avoid overlapping work:
 * please do **not** translate files from the web
-* follow the steps in [Getting Started](/about/translating/getting-started/) to _get the right file to translate_ and to ensure that the resource is ready for you to translate
+* follow the [step-by-step guide](/about/translating/step-by-step/) to _get the right file to translate_ and to ensure that the resource is ready for you to translate.
 
 ### If you want to translate a WAI resource:
 
-- Follow instructions in [Getting Started](/about/translating/getting-started/).
-- You will find more detailed guidance in [Translations Guides](/about/translating/guides/).
+- Follow instructions in [[Step-by-Step Guide to Translating WAI Resources]](/about/translating/step-by-step/).
+- You will find more detailed guidance in [[Translations Guides]](/about/translating/guides/).
 
 We encourage you to keep up on related translations work by [subscribing to the WAI Translations mailing list](mailto:public-wai-translations-request@w3.org?subject=subscribe).
    

--- a/_about/translating/guides.md
+++ b/_about/translating/guides.md
@@ -3,18 +3,19 @@ title: "Translations Guides"
 nav_title: Guides
 github:
   repository: w3c/wai-about-wai
-  path: '_about/translating/translations-guides.md'
+  path: '_about/translating/guides.md'
 permalink: /about/translating/guides/
 ref: /about/translating/guides/
 lang: en
-last_updated: 2023-11-06
+last_updated: 2023-11-09
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 6 November 2023.</p>
-  <p><strong>Editor:</strong> Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 ## Guides

--- a/_about/translating/guides/new-translation.md
+++ b/_about/translating/guides/new-translation.md
@@ -7,15 +7,16 @@ github:
 permalink: /about/translating/guides/new-translation/
 ref: /about/translating/guides/new-translation/
 lang: en
-last_updated: 2023-11-06
+last_updated: 2023-11-09
 
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 6 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::options toc_levels="2,3" /}

--- a/_about/translating/guides/review-translation.md
+++ b/_about/translating/guides/review-translation.md
@@ -2,7 +2,7 @@
 title: "Reviewing a Translation"
 nav_title: Reviewing a translation
 lang: en
-last_updated: 2023-11-06
+last_updated: 2023-11-09
 
 # Do not delete the following translators/contributors lines, used to display an example in the page.
 translators:
@@ -24,8 +24,9 @@ image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 7 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::options toc_levels="2,3" /}

--- a/_about/translating/guides/translation-guidance.md
+++ b/_about/translating/guides/translation-guidance.md
@@ -7,14 +7,15 @@ github:
 permalink: /about/translating/guides/translation-guidance/
 ref: /about/translating/guides/translation-guidance/
 lang: en
-last_updated: 2023-11-07
+last_updated: 2023-11-09
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 7 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::options toc_levels="2" /}

--- a/_about/translating/guides/using-github.md
+++ b/_about/translating/guides/using-github.md
@@ -7,15 +7,16 @@ github:
 permalink: /about/translating/guides/using-github/
 ref: /about/translating/guides/using-github/
 lang: en
-last_updated: 2023-11-07
+last_updated: 2023-11-09
 
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 7 November 2023.</p>
-   <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> Rémi Bétin and <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 inline_css: |
    figure.screenshot {

--- a/_about/translating/guides/video-subtitles.md
+++ b/_about/translating/guides/video-subtitles.md
@@ -7,15 +7,16 @@ github:
 permalink: /about/translating/guides/video-subtitles/
 ref: /about/translating/guides/video-subtitles/
 lang: en
-last_updated: 2023-11-07
+last_updated: 2023-11-09
 
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 7 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::options toc_levels="2" /}

--- a/_about/translating/sitemaps/sitemap-ar.md
+++ b/_about/translating/sitemaps/sitemap-ar.md
@@ -13,6 +13,8 @@ description: Help make the Web accessible to people with disabilities around the
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
+footer: |
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 #Custom frontmatter for this page
 tlang: ar

--- a/_about/translating/sitemaps/sitemap-es.md
+++ b/_about/translating/sitemaps/sitemap-es.md
@@ -13,6 +13,8 @@ description: Help make the Web accessible to people with disabilities around the
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
+footer: |
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 #Custom frontmatter for this page
 tlang: es

--- a/_about/translating/sitemaps/sitemap-fr.md
+++ b/_about/translating/sitemaps/sitemap-fr.md
@@ -13,6 +13,8 @@ description: Help make the Web accessible to people with disabilities around the
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
+footer: |
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 #Custom frontmatter for this page
 tlang: fr

--- a/_about/translating/sitemaps/sitemap-ru.md
+++ b/_about/translating/sitemaps/sitemap-ru.md
@@ -13,6 +13,8 @@ description: Help make the Web accessible to people with disabilities around the
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
+footer: |
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 #Custom frontmatter for this page
 tlang: ru

--- a/_about/translating/sitemaps/sitemap-zh-hans.md
+++ b/_about/translating/sitemaps/sitemap-zh-hans.md
@@ -13,6 +13,8 @@ description: Help make the Web accessible to people with disabilities around the
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
+footer: |
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 
 #Custom frontmatter for this page
 tlang: zh-hans

--- a/_about/translating/step-by-step.md
+++ b/_about/translating/step-by-step.md
@@ -1,12 +1,12 @@
 ---
-title: "Getting Started with Translating WAI Resources"
-nav_title: Getting Started
+title: "Step-by-Step Guide to Translating WAI Resources"
+nav_title: Step-by-Step
 github:
   repository: w3c/wai-about-wai
-  path: '_about/getting-started-translating.md'
-permalink: /about/translating/getting-started/
-last_updated: 2023-11-06
-ref: /about/translating/getting-started/
+  path: '_about/translating/step-by-step.md'
+permalink: /about/translating/step-by-step/
+last_updated: 2023-11-09
+ref: /about/translating/step-by-step/
 lang: en
 
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
@@ -14,8 +14,9 @@ image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 6 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a> and Rémi Bétin.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 {::nomarkdown}
@@ -43,6 +44,12 @@ To get announcements related to WAI translations, subscribe to the WAI Translati
 {::nomarkdown}
 {% include_cached toc.html type="end" %}
 {:/}
+
+Thank you for taking the time to contribute to WAI accessibility resources translations! 
+
+This resource will guide you through the important steps to creating and reviewing translations. 
+
+Before starting your work, please take the time to read the information in [[Translating WAI Resources]](/about/translating/), and verify that you are willing to contribute under these policies.
 
 ## GitHub
 
@@ -165,8 +172,8 @@ We have enabled a preview with Netlify so you can check your file and make edits
   - When done, it will say **"✅ Deploy Preview for _wai-repo-name_ ready!"** and a "Deploy Preview" link will appear.
 
 3. Click on the preview link:
-  - Check everything listed in [Reviewer Guidance]({{ "/about/translating/guides/review-translation/" | relative_url }}#initial-things-to-check)
-  - Eventually, commit some fixes.
+  - Check everything listed in [Reviewer Guidance](/about/translating/guides/review-translation/#initial-things-to-check);
+  - Eventually, commit some fixes;
   - At this point, if you encounter some technical problems, ask for help from WAI team.
 
 4. When your auto-review is done, go to the next step.
@@ -201,8 +208,7 @@ If you have any questions about the wording, please report them in the GitHub is
 When the review is done, WAI team will:
 - do some final checks;
 - merge the Pull Request;
-- publish the translation on WAI website;
-- announce the publication in the publicly-archived [public-wai-translations@w3.org](mailto:ublic-wai-translations@w3.org) mailing list.
+- publish the translation on WAI website.
 
 Please note these steps may take some time depending on other ongoing priorities.
 
@@ -296,7 +302,7 @@ First and foremost, send an email to [group-wai-translations@w3.org](group-wai-t
 
 {% include excol.html type="middle" %}
 
-Follow [Reviewing translations]({{ "/about/translating/guides/review-translation/" | relative_url }}) step-by-step guide.
+Follow [Reviewing translations](/about/translating/guides/review-translation/) step-by-step guide.
 
 {% include excol.html type="end" %}
 

--- a/_about/translating/translations-sitemaps.md
+++ b/_about/translating/translations-sitemaps.md
@@ -3,23 +3,34 @@ title: "Translations Sitemaps"
 nav_title: Translations Sitemaps
 github:
   repository: w3c/wai-about-wai
-  path: '_about/translating/translation-sitemaps.md'
+  path: '_about/translating/translations-sitemaps.md'
 permalink: /about/translating/sitemaps/
 ref: /about/translating/sitemaps/
 lang: en
-last_updated: 2023-11-06
+last_updated: 2023-11-09
 description: Help make the Web accessible to people with disabilities around the world. We appreciate your contributions to translating W3C WAI accessibility resources.
 image: /content-images/wai-about-wai/social-translations.png
 
 feedbackmail: wai@w3.org
 footer: |
-  <p><strong>Date:</strong> Updated 6 November 2023.</p>
-  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Rémi Bétin.</p>
+  <p><strong>Date:</strong> Updated 9 November 2023.</p>
+  <p><strong>Editors:</strong> Rémi Bétin and <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>.</p>
+  <p>Developed as part of the <a href="https://www.w3.org/WAI/about/projects/wai-coop/">WAI-CooP project</a>, co-funded by the European Commission.</p>
 ---
 
 Translation sitemaps display the structure of WAI website, and indicate for each page:
 - If a translation has been published for this language + its current status ({% include_cached icon.html name="check-circle" %} Up-to-date / {% include_cached icon.html name="warning" %} Needs update).
 - If a page has no translation available in this language, and therefore welcomes a volunteer translation.
+
+{::nomarkdown}
+{% include box.html type="start" title="Note" class="simple" %}
+{:/}
+
+We will add more sitemaps in November 2023.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
 
 ## Current Translations Sitemaps
   - [Arabic (ar)](/about/translating/sitemaps/sitemap-ar/)


### PR DESCRIPTION
- Add reference to WAI-CooP project
- Rename Getting Started Page
- Update editors
- Link from Step-by-Step to Translating page.

Note: the preview does no show the new name and url of the "Step-by-Step Guide" (formerly "Getting Started") in the navigation. Direct link: https://deploy-preview-233--wai-about-wai.netlify.app/about/translating/step-by-step/

### Dependency
- Merge https://github.com/w3c/wai-website-data/pull/112 along with this PR before publishing.