### PR TITLE
Conformance testing work statement 2024

### DIFF
--- a/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
+++ b/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
@@ -1,0 +1,89 @@
+---
+title: Accessibility Conformance Testing (ACT) Task Force Work Statement (2024)
+# nav_title:
+# order: 5
+# group: groups
+permalink: /about/groups/agwg/task-forces/conformance-testing/work-statement/
+ref: /about/groups/agwg/task-forces/conformance-testing/work-statement/
+lang: en
+github:
+  repository: w3c/wai-about-wai
+  path: /_about/groups/agwg/task-forces/conformance-testing/work-statement.md'
+---
+
+<p>The <a href=".">Accessibility Conformance Testing Task Force (ACT TF)</a> is a task force of the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group (AG WG)</a>. It assists this Working Group with the work identified below.</p>
+<section id="status">
+	<h2>Status</h2>
+	<p>This Work Statement was proposed to AGWG on xx xx 2024 and will be active if approved. The prior <a href="work-statement-2020">2020 work statement</a> is available. The <a href=".">Task Force home page</a> contains information about the operation and resources of this group. </p>
+</section>
+<section id="objective">
+	<h2>Objective</h2>
+	<p>The objective of the Accessibility Conformance Testing (ACT) Task Force is to evolve and maintain a repository of ACT Rules for <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">WCAG 2</a>, as well as for other W3C specifications, including <a href="https://www.w3.org/WAI/standards-guidelines/aria/">WAI-ARIA</a>, to promote a unified interpretation among different web accessibility test tools and methodologies. ACT Rules conform to the <a href="https://www.w3.org/WAI/standards-guidelines/act/">ACT Rules Format 1.0</a> to document different testing practices. The ACT TF reviews ACT Rules, and present them to AGWG when they meet stringent quality criteria. AGWG may publish such ACT Rules as non-normative W3C resources, as part of the supplemental guidance for WCAG 2.</p>
+</section>
+<section id="scope">
+	<h2>Scope of Work</h2>
+	<p>The work of the Accessibility Conformance Testing (ACT) Task Force includes:</p>
+	<ul>
+		<li><strong>Repository of ACT Rules:</strong> Review ACT Rules contributed to W3C, such as from <a href="https://act-rules.github.io/">ACT Rules Community Group</a>, and maintain a repository of rules approved by W3C Working Groups, including AGWG and ARIA</li>
+		<li><strong>Implementations Monitoring:</strong> Encourage and gather implementation reports from accessibility test tools and methodologies for ACT Rules published by AGWG</li>
+		<li><strong>Specification Maintenance:</strong> Maintain <a href="https://www.w3.org/WAI/GL/task-forces/conformance-testing/errata">Errata</a> for <a href="https://www.w3.org/TR/act-rules-format/">ACT Rules Format 1.0 specification</a>, and gather feature requests for future versions of this specification</li>
+		<li><strong>Silver Collaboration:</strong> Coordinate with <a href="https://www.w3.org/WAI/GL/">AGWG</a> and its <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a> to exchange ideas for conformance testing and to integrate ACT in future guidelines</li>
+		<li><strong>ACT Community Support:</strong> Promote the work of ACT within W3C and externally, and encourage participation and contribution by different key stakeholders</li>
+	</ul>
+</section>
+<section id="approach">
+	<h2>Approach</h2>
+	<p>This work builds on the earlier work carried out by ACT TF and on the work that continues to be carried out by the <a href="https://act-rules.github.io/">ACT Rules Community Group</a>. In particular, ACT Rules development continues to take place in the ACT-R CG with oversight by the Task Force. This is to maximize participation and leverage contribution by the broader community, while ensuring close coordination and harmonization with the Web Content Accessibility Guidelines (WCAG).</p>
+			<p>ACT TF will update the ACT-rules Format to version 1.1</p>
+	<p>ACT TF will continue to gather implementation experience, including of the <a href="https://www.w3.org/TR/act-rules-format/">ACT Rules Format 1.0 specification</a>, <a href="https://www.w3.org/TR/act-rules-aspects/">Common Input Aspects note</a>, <a href="https://www.w3.org/WAI/standards-guidelines/earl/">Evaluation and Report Language (EARL)</a>, and related W3C guidance. ACT TF may update or develop additional non-normative guidance, for example to help explain ACT and its uses.</p>
+</section>
+<section id="dependencies">
+	<p>The Accessibility Conformance Testing (ACT) Task Force depends on:</p>
+	<ul>
+		<li><a href="https://www.w3.org/WAI/GL/">AG WG</a> to ensure accurate interpretation and representation of WCAG requirements;</li>
+		<li><a href="https://www.w3.org/WAI/ARIA/">ARIA WG</a> to ensure accurate interpretation and representation of WAI-ARIA requirements;</li>
+		<li><a href="https://act-rules.github.io/">ACT Rules Community Group</a> to utilize this group's contribution on conformance testing.</li>
+	</ul>
+	<p>The Accessibility Conformance Testing (ACT) Task Force will also coordinate with relevant W3C groups and activities on testing and quality assurance. This may include groups such as <a href="https://www.w3.org/testing/browser/">Browser Testing and Tools Working Group</a>. The Task Force may also coordinate with the <a href="https://www.w3.org/WAI/EO/">Education and Outreach Working Group (EOWG)</a> where necessary to improve the writing, presentation, and educational value of the developed materials. </p>
+</section>
+<section id="communication">
+	<h2>Communication</h2>
+	<p>The communications of the Accessibility Conformance Testing (ACT) Task Force are publicly visible. Communication mechanisms include:</p>
+	<ul>
+		<li>Up-to-date task force homepage;</li>
+		<li>Publicly archived mailing list;</li>
+		<li>Public GitHub and Wiki spaces;</li>
+		<li>Public group surveys and minutes;</li>
+		<li>Regular updates to the AGWG;</li>
+		<li>Scheduled deliverable reviews.</li>
+	</ul>
+</section>
+<section id="participation">
+	<h2>Participation</h2>
+	<p>To join this Accessibility Conformance Testing (ACT) Task Force, individuals must be participants of AG WG. Participants are expected to actively contribute to the work of the task force, including:</p>
+	<ul>
+		<li>Minimum 4 hours per week of task force work (this time also counts towards the individual's participation requirement in the AG WG);</li>
+		<li>Remain current on the task force mailing list and respond in a timely manner to postings;</li>
+		<li>Participate regularly in task force telephone meetings, or send regrets ahead of time.</li>
+	</ul>
+	<p>Participants may also join Accessibility Conformance Testing Task Force sub-groups. Sub-groups take on specific assignments for the Accessibility Conformance Testing Task Force.</p>
+	<p>If you are interested in becoming a participant of the Accessibility Conformance Testing Task Force or have any questions regarding its work, contact the task force facilitators.</p>
+	<p><a href="https://www.w3.org/2000/09/dbwg/details?group=93339&amp;public=1">Current participants in the ACT TF</a>.</p>
+</section>
+<section id="facilitation">
+	<h2>Facilitation</h2>
+	<p>Staff contacts from the AG Working Group oversee attention to W3C Process with respect to the chartered requirements of the Working Group. The Facilitators set agenda, lead meetings, determine consensus, and are the primary liaison to the Working Group.</p>
+	<ul>
+		<li><strong>Facilitators:</strong>
+			<ul>
+				<li>Wilco Fiers, Deque Systems</li>
+				<li>Kathy Eng, Access Board</li>
+			</ul>
+		</li>
+		<li><strong>Staff Contact: </strong><a href="https://www.w3.org/staff/#dmontalvo/">Daniel Montalvo</a></li>
+	</ul>
+</section>
+<section id="patentpolicy">
+	<h2>Patent Policy</h2>
+	<p>This Task Force is part of the <a href="https://www.w3.org/WAI/GL/charter">AG Working Group Charter</a>, which operates under the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a> (5 February 2004 Version). W3C maintains a public list of any patent disclosures made in connection with the deliverables of the <a href="https://www.w3.org/2004/01/pp-impl/35422/status">AG Working Group</a>.</p>
+</section>

--- a/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
+++ b/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
@@ -24,7 +24,7 @@ github:
 	<h2>Scope of Work</h2>
 	<p>The work of the Accessibility Conformance Testing (ACT) Task Force includes:</p>
 	<ul>
-		<li><strong>Repository of ACT Rules:</strong> Review ACT Rules contributed to W3C, such as from <a href="https://act-rules.github.io/">Accessibility Conformance Testing Rules Community Group (ACT-R CG</a>, and maintain a repository of rules approved by W3C Working Groups, including AG and ARIA</li>
+		<li><strong>Repository of ACT Rules:</strong> Review ACT Rules contributed to W3C, such as from <a href="https://act-rules.github.io/">Accessibility Conformance Testing Rules Community Group (ACT-R CG)</a>, and maintain a repository of rules approved by W3C Working Groups, including AG and ARIA</li>
 		<li><strong>Implementations Monitoring:</strong> Encourage and gather implementation reports from accessibility test tools and methodologies for ACT Rules published by AG WG</li>
 		<li><strong>Specification Maintenance:</strong> Maintain <a href="https://www.w3.org/WAI/GL/task-forces/conformance-testing/errata">Errata</a> for <a href="https://www.w3.org/TR/act-rules-format/">ACT Rules Format 1.0 specification</a>, and gather feature requests for future versions of this specification</li>
 		<li><strong>Silver Collaboration:</strong> Coordinate with <a href="https://www.w3.org/WAI/GL/">AG WG</a> and its <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a> to exchange ideas for conformance testing and to integrate ACT in future guidelines</li>

--- a/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
+++ b/_about/groups/agwg/task-forces/conformance-testing/work-statement.md
@@ -14,27 +14,27 @@ github:
 <p>The <a href=".">Accessibility Conformance Testing Task Force (ACT TF)</a> is a task force of the <a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group (AG WG)</a>. It assists this Working Group with the work identified below.</p>
 <section id="status">
 	<h2>Status</h2>
-	<p>This Work Statement was proposed to AGWG on xx xx 2024 and will be active if approved. The prior <a href="work-statement-2020">2020 work statement</a> is available. The <a href=".">Task Force home page</a> contains information about the operation and resources of this group. </p>
+	<p>This Work Statement was proposed to AG WG on xx xx 2024 and will be active if approved. The prior <a href="work-statement-2020">2020 work statement</a> is available. The <a href=".">Task Force home page</a> contains information about the operation and resources of this group. </p>
 </section>
 <section id="objective">
 	<h2>Objective</h2>
-	<p>The objective of the Accessibility Conformance Testing (ACT) Task Force is to evolve and maintain a repository of ACT Rules for <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">WCAG 2</a>, as well as for other W3C specifications, including <a href="https://www.w3.org/WAI/standards-guidelines/aria/">WAI-ARIA</a>, to promote a unified interpretation among different web accessibility test tools and methodologies. ACT Rules conform to the <a href="https://www.w3.org/WAI/standards-guidelines/act/">ACT Rules Format 1.0</a> to document different testing practices. The ACT TF reviews ACT Rules, and present them to AGWG when they meet stringent quality criteria. AGWG may publish such ACT Rules as non-normative W3C resources, as part of the supplemental guidance for WCAG 2.</p>
+	<p>ACT TF's objective is to evolve and maintain a repository of ACT Rules for <a href="https://www.w3.org/WAI/standards-guidelines/wcag/">Web Content Accessibility Guidelines 2 (WCAG 2)</a>, as well as for other W3C specifications, including <a href="https://www.w3.org/WAI/standards-guidelines/aria/">Accessible Rich Internet Applications (WAI-ARIA)</a>, to promote a unified interpretation among different web accessibility test tools and methodologies. ACT Rules conform to the <a href="https://www.w3.org/WAI/standards-guidelines/act/">ACT Rules Format 1.0</a> to document different testing practices. ACT TF reviews ACT Rules, and present them to AG WG when they meet stringent quality criteria. AG WG may publish such ACT Rules as non-normative W3C resources, as part of the supplemental guidance for WCAG 2.</p>
 </section>
 <section id="scope">
 	<h2>Scope of Work</h2>
 	<p>The work of the Accessibility Conformance Testing (ACT) Task Force includes:</p>
 	<ul>
-		<li><strong>Repository of ACT Rules:</strong> Review ACT Rules contributed to W3C, such as from <a href="https://act-rules.github.io/">ACT Rules Community Group</a>, and maintain a repository of rules approved by W3C Working Groups, including AGWG and ARIA</li>
-		<li><strong>Implementations Monitoring:</strong> Encourage and gather implementation reports from accessibility test tools and methodologies for ACT Rules published by AGWG</li>
+		<li><strong>Repository of ACT Rules:</strong> Review ACT Rules contributed to W3C, such as from <a href="https://act-rules.github.io/">Accessibility Conformance Testing Rules Community Group (ACT-R CG</a>, and maintain a repository of rules approved by W3C Working Groups, including AG and ARIA</li>
+		<li><strong>Implementations Monitoring:</strong> Encourage and gather implementation reports from accessibility test tools and methodologies for ACT Rules published by AG WG</li>
 		<li><strong>Specification Maintenance:</strong> Maintain <a href="https://www.w3.org/WAI/GL/task-forces/conformance-testing/errata">Errata</a> for <a href="https://www.w3.org/TR/act-rules-format/">ACT Rules Format 1.0 specification</a>, and gather feature requests for future versions of this specification</li>
-		<li><strong>Silver Collaboration:</strong> Coordinate with <a href="https://www.w3.org/WAI/GL/">AGWG</a> and its <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a> to exchange ideas for conformance testing and to integrate ACT in future guidelines</li>
+		<li><strong>Silver Collaboration:</strong> Coordinate with <a href="https://www.w3.org/WAI/GL/">AG WG</a> and its <a href="https://www.w3.org/WAI/GL/task-forces/silver/">Silver Task Force</a> to exchange ideas for conformance testing and to integrate ACT in future guidelines</li>
 		<li><strong>ACT Community Support:</strong> Promote the work of ACT within W3C and externally, and encourage participation and contribution by different key stakeholders</li>
 	</ul>
 </section>
 <section id="approach">
 	<h2>Approach</h2>
-	<p>This work builds on the earlier work carried out by ACT TF and on the work that continues to be carried out by the <a href="https://act-rules.github.io/">ACT Rules Community Group</a>. In particular, ACT Rules development continues to take place in the ACT-R CG with oversight by the Task Force. This is to maximize participation and leverage contribution by the broader community, while ensuring close coordination and harmonization with the Web Content Accessibility Guidelines (WCAG).</p>
-			<p>ACT TF will update the ACT-rules Format to version 1.1</p>
+	<p>This work builds on the earlier work carried out by ACT TF and on the work that continues to be carried out by the <a href="https://act-rules.github.io/">ACT-R CG</a>. In particular, ACT Rules development continues to take place in ACT-R CG with oversight by the Task Force. This is to maximize participation and leverage contribution by the broader community, while ensuring close coordination and harmonization with the Web Content Accessibility Guidelines (WCAG).</p>
+			<p>ACT TF will update the ACT rules Format to version 1.1</p>
 	<p>ACT TF will continue to gather implementation experience, including of the <a href="https://www.w3.org/TR/act-rules-format/">ACT Rules Format 1.0 specification</a>, <a href="https://www.w3.org/TR/act-rules-aspects/">Common Input Aspects note</a>, <a href="https://www.w3.org/WAI/standards-guidelines/earl/">Evaluation and Report Language (EARL)</a>, and related W3C guidance. ACT TF may update or develop additional non-normative guidance, for example to help explain ACT and its uses.</p>
 </section>
 <section id="dependencies">
@@ -54,7 +54,7 @@ github:
 		<li>Publicly archived mailing list;</li>
 		<li>Public GitHub and Wiki spaces;</li>
 		<li>Public group surveys and minutes;</li>
-		<li>Regular updates to the AGWG;</li>
+		<li>Regular updates to the AG WG;</li>
 		<li>Scheduled deliverable reviews.</li>
 	</ul>
 </section>


### PR DESCRIPTION
See [Work Statement Preview](https://deploy-preview-244--wai-about-wai.netlify.app/about/groups/agwg/task-forces/conformance-testing/work-statement/) on WAI website

- Please don´t comment on missing left nav for now. Placement of this Work statement in the WAI website served from GitHub will be discussed at a future stage.