### PR TITLE
Add Ken to WAI staff lists

### DIFF
--- a/_about/contacting.md
+++ b/_about/contacting.md
@@ -84,5 +84,6 @@ Comments on other parts of the W3C Web site (www.w3.org) go to: <site-comments@w
 * [Kevin White](https://www.w3.org/staff/#kevin) leads technical accessibility work, including oversight of accessibility Working Groups.
 * [Roy Ruoxi Ran](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
 * [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization in Europe.
+* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) is responsible for improvements to WAI website infrastructure.
 
 If you don't know who to contact, or to reach all WAI staff, you can e-mail <wai@w3.org>

--- a/_about/index.md
+++ b/_about/index.md
@@ -129,6 +129,7 @@ You can subscribe to get news announcements via e-mail, Atom/RSS feed, and socia
 * [Kevin White](https://www.w3.org/staff/#kevin) is Accessibility Technical Lead and supports the Accessibility Guidelines Working Group that develops Web Content Accessibility Guidelines (WCAG).
 * [Roy Ruoxi Ran (冉若曦)](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
 * [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization in Europe.
+* [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) is responsible for improvements to WAI website infrastructure.
 
 To reach all WAI staff, you can e-mail <wai@w3.org>
 

--- a/_about/update.md
+++ b/_about/update.md
@@ -166,6 +166,7 @@ We also offer ideas for [Promoting and Implementing Web Accessibility](https://w
   * [Kevin White](https://www.w3.org/staff/#kevin) is Accessibility Technical Lead and supports the Accessibility Guidelines Working Group that develops Web Content Accessibility Guidelines (WCAG).
   * [Roy Ruoxi Ran (冉若曦)](https://www.w3.org/staff/#ran) supports accessibility Working Groups and accessibility in China.
   * [Daniel Montalvo](https://www.w3.org/staff/#dmontalvo) supports accessibility Working Groups and standards harmonization in Europe.
+  * [Ken Franqueiro](https://www.w3.org/staff/#kfranqueiro) is responsible for improvements to WAI website infrastructure.
 * Participants of: [AG](https://www.w3.org/groups/wg/ag/participants), [APA](https://www.w3.org/groups/wg/apa/participants), [ARIA](https://www.w3.org/groups/wg/aria/participants), [EPUB](https://www.w3.org/groups/wg/epub/participants), [EO](https://www.w3.org/groups/wg/eowg/participants), and other [W3C groups](https://www.w3.org/groups/)
 
 <section class="default-grid teaser making-web-accessible" aria-labelledby="mwa-title" style="border: 1px solid var(--line-grey);">


### PR DESCRIPTION
It looks like we list our staff members in 3 places, so I updated all of them.

Feel free to suggest wording tweaks.

(It'd be nice if it were in one place or used an include to at least avoid repetition in the repo, but that's probably something to tackle later.)